### PR TITLE
Closes #100

### DIFF
--- a/js/actions/featureloader.js
+++ b/js/actions/featureloader.js
@@ -11,19 +11,21 @@ module.exports = {
     /**
      * start loading the features
      */
-    startFeatureLoader: (wmsURL, params = {}, configURL) => ({
+    startFeatureLoader: (wmsURL, params = {}, configURL, isWmsViewer = false) => ({
         type: STARTLOADING,
         wmsURL,
         layer: params.layer,
         cql_filter: params.cql_filter,
-        configURL
+        configURL,
+        isWmsViewer
     }),
-    updateFeatureLoader: (oldParams = {}, params = {}, wmsURL) => ({
+    updateFeatureLoader: (oldParams = {}, params = {}, wmsURL, isWmsViewer = false) => ({
         type: UPDATE,
         layer: params.layer,
         cql_filter: params.cql_filter,
         oldParams,
-        wmsURL
+        wmsURL,
+        isWmsViewer
     }),
     STARTLOADING,
     UPDATE

--- a/js/appConfig.js
+++ b/js/appConfig.js
@@ -17,9 +17,13 @@ module.exports = {
          path: "/viewer",
          component: require('./pages/MapViewer')
      }, {
-         name: "viewer",
+         name: "featureviewer",
          path: "/featureviewer/:mapType/:layer/:cql_filter",
          component: require('./pages/FeatureViewer')
+     }, {
+        name: "wmsviewer",
+        path: "/wmsfeatureviewer/:mapType/:layer/:cql_filter",
+        component: require('./pages/FeatureViewer')
      }, {
          name: "mapviewer",
          path: "/viewer/:mapType/:mapId",

--- a/js/appConfigEmbedded.js
+++ b/js/appConfigEmbedded.js
@@ -20,7 +20,11 @@ module.exports = {
         name: "mapviewer",
         path: "/viewer/:mapType/:mapId",
         component: require('./pages/MapViewer')
-    }],
+    }, {
+        name: "wmsviewer",
+        path: "/wmsfeatureviewer/:mapType/:layer/:cql_filter",
+        component: require('./pages/FeatureViewer')
+     }],
     pluginsDef: require('./apiPlugins'),
     translations: ["MapStore2/web/client/translations", "translations"],
     initialState: {

--- a/js/pages/FeatureViewer.jsx
+++ b/js/pages/FeatureViewer.jsx
@@ -16,6 +16,7 @@ const {resetControls} = require('../../MapStore2/web/client/actions/controls');
 const {startFeatureLoader, updateFeatureLoader} = require('../actions/featureloader');
 
 const MapViewer = require('../containers/FeatureViewer');
+const isWmsViewer = path => path.indexOf("/wmsfeatureviewer") !== -1;
 
 class MapViewerPage extends React.Component{
     static propTypes = {
@@ -34,7 +35,7 @@ class MapViewerPage extends React.Component{
     };
 
     componentWillMount() {
-        this.props.onMount(ConfigUtils.getConfigProp("wmsURL"), this.props.match.params, "config.json");
+        this.props.onMount(ConfigUtils.getConfigProp("wmsURL"), this.props.match.params, "config.json", isWmsViewer(this.props.match.path));
         if (!ConfigUtils.getDefaults().ignoreMobileCss) {
             if (this.props.mode === 'mobile') {
                 require('../../MapStore2/web/client/product/assets/css/mobile.css');
@@ -43,7 +44,7 @@ class MapViewerPage extends React.Component{
     }
     componentDidUpdate(prevProps) {
         if (this.props.match.params !== prevProps.params) {
-            this.props.onUpdate(prevProps, this.props.match.params, ConfigUtils.getConfigProp("wmsURL"));
+            this.props.onUpdate(prevProps, this.props.match.params, ConfigUtils.getConfigProp("wmsURL"), isWmsViewer(this.props.match.path));
         }
     }
     render() {


### PR DESCRIPTION
## Description
Visualize only the wms layer filtred by passed cql filter
## Issues
 - Fix #100

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#100 

**What is the new behavior?**
If user navigate to /wmsfeatureviewer/:mapType/:layer/:cql_filter the featureviewer will display only the wms layer filtred by the cql filter
Also fix the getFeatureInfo that is not going to search in vector layer any more.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
