### PR TITLE
Fix #108 Add GeoJSON to the export formats

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -375,6 +375,10 @@
             {
               "name": "dxf-zip",
               "label": "dxf-zip"
+            },
+            {
+              "name": "application/json",
+              "label": "GeoJSON"
             }
           ],
           "srsList": [


### PR DESCRIPTION
## Description
Added GeoJSON format to WFS Download.
Needed MapStore2 revision update.

## Issues
 - Fix #108

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
Missing GeoJSON format in feature grid download

**What is the new behavior?**
Added GeoJSON format in feature grid download

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Needed  MapStore2 revision update.