### PR TITLE
fix #140 and also search bar in lavori pubblici plugin

### DIFF
--- a/lavoriPubblici.html
+++ b/lavoriPubblici.html
@@ -77,6 +77,12 @@
             70% {opacity: .75}
             100%{opacity: 0}
         }
+        .page.page-cantieri .search-result-list {
+            left: 65px;
+        }
+        .MapSearchBar .input-group{
+            width: 100%;
+        }
         </style>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway" type='text/css'>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.3.4/ol.css" />

--- a/localConfig.json
+++ b/localConfig.json
@@ -80,6 +80,14 @@
     "mobile": [{
         "name": "Map",
         "cfg": {
+          "mapOptions": {
+            "openlayers": {
+              "interactions": {
+                "altShiftDragRotate": false,
+                "pinchRotate": false
+              }
+            }
+          },
           "tools": ["locate"]
         }
       }, "Version", "DrawerMenu",
@@ -217,6 +225,10 @@
         "cfg":{
           "mapOptions": {
             "openlayers": {
+              "interactions": {
+                "altShiftDragRotate": false,
+                "pinchRotate": false
+              },
               "view": {
                 "minZoom": 10,
                 "extent": [
@@ -749,6 +761,10 @@
           "tools": ["locate", "draw", "highlight"],
           "mapOptions": {
             "openlayers": {
+              "interactions": {
+                "altShiftDragRotate": false,
+                "pinchRotate": false
+              },
               "attribution": {
                 "container": "#mapstore-map-footer-container"
               }
@@ -894,8 +910,16 @@
     "cantieri": [{
       "name": "Map",
       "cfg" :{
-          "mapType": "openlayers",
-          "tools": ["measurement", "locate", "draw", "highlight"]
+        "mapOptions": {
+          "openlayers": {
+            "interactions": {
+              "altShiftDragRotate": false,
+              "pinchRotate": false
+            }
+          }
+        },
+        "mapType": "openlayers",
+        "tools": ["measurement", "locate", "draw", "highlight"]
       }
     }, "Notifications", "LavoriPubblici",
         {


### PR DESCRIPTION
## Description
updated lavori pubblici plugin search bar style. 

## Issues
 - Fix #140
 - Fix #146 
 - Fix #143
 - Fix #142

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
- you can rotate and the tool has wrong style.
- synch popover does not appear
- search bar is too short
- you can't go from feature grid to to chart wizard

**What is the new behavior?**
- map rotation has been disabled.
- synch map has now a popover 
- search bar is now longer in lavori pubblici plugin
- now you can go from feature grid to the chart wizard tool and viceversa if the back tool is clicked

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
