### PR TITLE
Privacy Note and Cookies

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -66,6 +66,7 @@ module.exports = {
         HeaderPlugin: require('./plugins/Header'),
         FooterPlugin: require('./plugins/Footer'),
         AttributionPlugin: require('./plugins/Attribution'),
+        PrivacyNote: require('./plugins/PrivacyNote'),
         FeatureLoader: require('./plugins/FeatureLoader'),
         NotificationsPlugin: require('../MapStore2/web/client/plugins/Notifications'),
         FeatureEditorPlugin: require('../MapStore2/web/client/plugins/FeatureEditor'),

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -35,6 +35,7 @@ module.exports = {
         MetadataExplorerPlugin: require('../MapStore2/web/client/plugins/MetadataExplorer'),
         LoginPlugin: require('./plugins/Login'),
         OmniBarPlugin: require('../MapStore2/web/client/plugins/OmniBar'),
+        CookiePlugin: require('../MapStore2/web/client/plugins/Cookie'),
         BurgerMenuPlugin: require('../MapStore2/web/client/plugins/BurgerMenu'),
         UndoPlugin: require('../MapStore2/web/client/plugins/History'),
         RedoPlugin: require('../MapStore2/web/client/plugins/History'),
@@ -80,7 +81,6 @@ module.exports = {
         FloatingLegend: require('../MapStore2/web/client/plugins/FloatingLegend'),
         Dashboards: require('../MapStore2/web/client/plugins/Dashboards'),
         ContentTabs: require('../MapStore2/web/client/plugins/ContentTabs')
-
     },
     requires: {
         ReactSwipe: require('react-swipeable-views').default,

--- a/js/plugins/Footer.jsx
+++ b/js/plugins/Footer.jsx
@@ -12,7 +12,10 @@ const Footer = React.createClass({
     render() {
         return (
             <div className="ms-footer col-md-12">
-            <div><a target="_blank" href="http://www.comune.genova.it/"> <img src={src} width="140" title="Comune di Genova" alt="Comune di Genova" /></a> <br/><br/></div>
+            <div><a target="_blank" href="http://www.comune.genova.it/"> <img src={src} width="140" title="Comune di Genova" alt="Comune di Genova" /></a>
+                <br/><br/></div>
+                <a target="_blank" href="http://www.comune.genova.it/content/note-legali-e-privacy">Privacy</a>
+                <br />
                 Comune di Genova  - Palazzo Tursi  -  Via Garibaldi 9  -  16124 Genova  | Centralino 010.557111 <br/>
                 Pec: comunegenova@postemailcertificata.it - C.F. / P. Iva 00856930102
             </div>

--- a/js/plugins/PrivacyNote.jsx
+++ b/js/plugins/PrivacyNote.jsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const PropTypes = require('prop-types');
+const assign = require('object-assign');
+
+const { Button } = require('react-bootstrap');
+class PrivacyNote extends React.Component {
+    static propTypes = {
+        options: PropTypes.object,
+        url: PropTypes.string
+    }
+    static defaultProps = {
+        url: 'http://www.comune.genova.it/content/note-legali-e-privacy',
+        options: {}
+    }
+
+    render() {
+        return (<Button bsSize="sm" bsStyle="primary" style={{"float": "right"}} target="_blank" href={this.props.url} {...this.props.options} >Privacy</Button>);
+    }
+}
+
+module.exports = {
+    PrivacyNotePlugin: assign(PrivacyNote, {
+        MapFooter: {
+            name: 'privacyNote',
+            position: 100,
+            tool: true,
+            priority: 1
+        }
+    })
+};

--- a/localConfig.json
+++ b/localConfig.json
@@ -525,7 +525,7 @@
             }
           }
         }
-      }, "MapFooter", {
+      }, "MapFooter", "PrivacyNote", {
         "name": "Search",
         "cfg": {
           "searchOptions": {
@@ -619,7 +619,7 @@
       },
       "OmniBar", "Login", "Save", "SaveAs", "BurgerMenu", "Expander", "Undo", "Redo", "FullScreen",
       "GlobeViewSwitcher", "SearchServicesConfig", "AutoMapUpdate",  "Widgets", "WidgetsBuilder",
-      "FloatingLegend", {
+      {
         "name": "Cookie",
         "cfg": {
           "externalCookieUrl": "http://www.comune.genova.it/content/note-legali-e-privacy",

--- a/localConfig.json
+++ b/localConfig.json
@@ -619,7 +619,13 @@
       },
       "OmniBar", "Login", "Save", "SaveAs", "BurgerMenu", "Expander", "Undo", "Redo", "FullScreen",
       "GlobeViewSwitcher", "SearchServicesConfig", "AutoMapUpdate",  "Widgets", "WidgetsBuilder",
-      "FloatingLegend"
+      "FloatingLegend", {
+        "name": "Cookie",
+        "cfg": {
+          "externalCookieUrl": "http://www.comune.genova.it/content/note-legali-e-privacy",
+          "declineUrl": "http://www.google.com"
+        }
+      }
     ],
     "embedded": [{
         "name": "Map",
@@ -932,6 +938,12 @@
           },
           "fluid": true
         }
+      },{
+        "name": "Cookie",
+        "cfg": {
+          "externalCookieUrl": "http://www.comune.genova.it/content/note-legali-e-privacy",
+          "declineUrl": "http://www.google.com"
+        }
       },
       "Footer"
     ],
@@ -1004,7 +1016,13 @@
         "name": "Header",
         "hide": true
       },
-      "Notifications", "Home"
+      "Notifications", "Home", {
+        "name": "Cookie",
+        "cfg": {
+          "externalCookieUrl": "http://www.comune.genova.it/content/note-legali-e-privacy",
+          "declineUrl": "http://www.google.com"
+        }
+      }
     ],
     "cantieri": [{
       "name": "Map",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "leaflet.locatecontrol": "0.62.0",
     "leaflet.nontiledlayer": "1.0.7",
     "lodash": "4.16.6",
+    "lru-cache": "4.1.2",
     "moment": "2.21.0",
     "node-geo-distance": "1.2.0",
     "node-uuid": "1.4.3",
@@ -201,6 +202,7 @@
     "url": "0.10.3",
     "uuid": "3.0.1",
     "w3c-schemas": "1.3.1",
+    "wellknown": "0.5.0",
     "wkt-parser": "https://github.com/geosolutions-it/wkt-parser/tarball/mapstore2_fixes",
     "xml2js": "0.4.17"
   },


### PR DESCRIPTION
## Description
 - Add privacy link in footer (map and home)
 - Add popup for cookies  

The "More Details" button and the "Privacy" link in footer link to `http://www.comune.genova.it/content/note-legali-e-privacy`

## Issues
 - Fix #156
 
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Screenshots
![image](https://user-images.githubusercontent.com/1279510/40548902-512e0c1c-6036-11e8-963f-d3e007c5ad81.png)
![image](https://user-images.githubusercontent.com/1279510/40548981-901f49fe-6036-11e8-94a8-05a5e81a9c42.png)
![image](https://user-images.githubusercontent.com/1279510/40549010-9e8f501a-6036-11e8-803a-fd7aee0bdf8f.png)

Map Privacy link: 
![image](https://user-images.githubusercontent.com/1279510/40550572-c8b5f76e-603a-11e8-8bbf-66af5a303623.png)

