### PR TITLE
fix coordinate editor configuration for mobile and fix #221 default info format

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -86,11 +86,18 @@
           }
         }
       },
-        "wfsdownload": {
-          "downloadOptions":{
-            "singlePage": false
-          }
+      "wfsdownload": {
+        "downloadOptions":{
+          "singlePage": false
         }
+      },
+      "mapInfo": {
+        "enabled": true,
+        "disabledAlwaysOn": false,
+        "configuration": {
+          "infoFormat": "text/html"
+        }
+      }
     }
   },
    "monitorState": [
@@ -699,12 +706,12 @@
         "cfg": {
           "enabledCoordEditorButton": false,
           "showFullscreen": true,
-                    "position": "bottom",
-                    "size": 0.5,
-                    "fluid": true,
-                    "viewerOptions": {
-                        "container": "{context.ReactSwipe}"
-                    },
+            "position": "bottom",
+            "size": 0.5,
+            "fluid": true,
+            "viewerOptions": {
+                "container": "{context.ReactSwipe}"
+            },
           "glyph": "info-sign"
         }
       }, {

--- a/localConfig.json
+++ b/localConfig.json
@@ -130,13 +130,14 @@
         "name": "Identify",
         "showIn": ["Settings"],
         "cfg": {
-          	"showFullscreen": true,
-		"position": "bottom",
-		"size": 0.5,
-		"fluid": true,
-		"viewerOptions": {
-			"container": "{context.ReactSwipe}"
-		}
+          "enabledCoordEditorButton": false,
+          "showFullscreen": true,
+      		"position": "bottom",
+      		"size": 0.5,
+      		"fluid": true,
+      		"viewerOptions": {
+      			"container": "{context.ReactSwipe}"
+      		}
         }
       }, {
         "name": "Locate",
@@ -166,8 +167,8 @@
       },
        {
         "name": "Search",
-        "showOptions": false,
         "cfg": {
+          "showOptions": false,
           "withToggle": ["max-width: 768px", "min-width: 768px"],
           "searchOptions": {
             "services": [{
@@ -844,6 +845,7 @@
       }, {
           "name": "Identify",
           "cfg": {
+              "enabledCoordEditorButton": false,
               "panelClassName": "mapstore-right-panel modal-content",
               "glyph": "info-sign",
               "draggable": false,


### PR DESCRIPTION
## Description
this pre removes coordiante editor from mobile in GFI and search

it also updates the mapstore to the latest commit (1101171e3e672ea40bbea713747d6b0782f68138)

it also updates the configuration for changing default info format to HTML

## Issues
 - #221 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
