### PR TITLE
Fix 212 changed translations of expand/collapse tooltip

### DIFF
--- a/translations/data.de-DE
+++ b/translations/data.de-DE
@@ -1,6 +1,8 @@
 {
     "locale": "de-DE",
     "messages": {
+        "collapse": "Vollständige Beschreibung ausblenden",
+        "expand": "Vollständige Beschreibung anzeigen",
         "search": {
             "s_priority_info": "Wird verwendet, um Suchergebnisse zu sortieren, höhere Werte zuerst. Die Standarddienste haben Vorrang 5 und 6"
         },

--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -1,6 +1,8 @@
 {
     "locale": "en-US",
     "messages": {
+        "collapse": "Hide full description",
+        "expand": "Show full decription",
         "search": {
             "s_priority_info": "Used to sort search results, higher values first. Default services has priority 5 and 6"
         },

--- a/translations/data.fr-FR
+++ b/translations/data.fr-FR
@@ -1,6 +1,8 @@
 {
     "locale": "fr-FR",
     "messages": {
+        "collapse": "Masquer la description complète",
+        "expand": "Afficher la description complète",
         "search": {
             "s_priority_info": "Utilisé pour trier les résultats de recherche, des valeurs plus élevées en premier. Les services par défaut ont priorité 5 et 6"
         },

--- a/translations/data.it-IT
+++ b/translations/data.it-IT
@@ -1,6 +1,8 @@
 {
     "locale": "it-IT",
     "messages": {
+        "collapse": "Nascondi descrizione completa",
+        "expand": "Mostra descrizione completa",
         "search": {
             "s_priority_info": "Usato per ordinare i risultati, i valori più alti vengono visualizzati per primi. I servizi di default (ricerca strade/indirizzi e nominatim) hanno rispettivamente priorità 6 e 5"
         },


### PR DESCRIPTION
## Description
restoring old translaions for expand/collapse tooltip in catalog layer card

## Issues
 - #212

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
the text for the tooltp are "expand/collapse"

**What is the new behavior?**
text is "Show full description/Hide dull dscription"

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
