### PR TITLE
update a config of tutorial gfi step

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -492,7 +492,7 @@
               },
               {
                 "translation": "identifyButton",
-                "selector": "#navigationBar-container glyphicon.glyphicon-option-horizontal",
+                "selector": "#navigationBar-container .glyphicon.glyphicon-option-horizontal",
                 "position": "top"
               }
             ]

--- a/localConfig.json
+++ b/localConfig.json
@@ -492,7 +492,7 @@
               },
               {
                 "translation": "identifyButton",
-                "selector": "#identifyBar-container",
+                "selector": "#navigationBar-container glyphicon.glyphicon-option-horizontal",
                 "position": "top"
               }
             ]


### PR DESCRIPTION
## Description
this pr fix a bad configuration for gfi step.

but the real fix is on mapstore that need to be aligned after [this](https://github.com/geosolutions-it/MapStore2/pull/3943) is merged in master

as far as i could test quicly that configuration is not used.  anyway i'm fixint it.

## Issues
 -  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
