### PR TITLE
#406: removed redundant and old dependencies of print-lib

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -65,66 +65,6 @@
         <artifactId>print-lib</artifactId>
         <version>geosolutions-2.0</version>
     </dependency>
-    <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-epsg-hsql</artifactId>
-        <version>8.6</version>
-    </dependency>
-    <dependency>
-        <groupId>org.jyaml</groupId>
-        <artifactId>jyaml</artifactId>
-        <version>1.3</version>
-    </dependency>
-    <dependency>
-        <groupId>com.vividsolutions</groupId>
-        <artifactId>jts</artifactId>
-        <version>1.8</version>
-    </dependency>
-    <dependency>
-        <groupId>org.mapfish.geo</groupId>
-        <artifactId>mapfish-geo-lib</artifactId>
-        <version>1.2.0</version>
-    </dependency>
-    <dependency>
-        <groupId>javax.media</groupId>
-        <artifactId>jai_codec</artifactId>
-        <version>1.1.3</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.pdfbox</groupId>
-        <artifactId>pdfbox</artifactId>
-        <version>1.6.0</version>
-    </dependency>
-    <dependency>
-        <groupId>javax.media</groupId>
-        <artifactId>jai_imageio</artifactId>
-        <version>1.1</version>
-    </dependency>
-    <dependency>
-        <groupId>commons-httpclient</groupId>
-        <artifactId>commons-httpclient</artifactId>
-        <version>3.1</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.xmlgraphics</groupId>
-        <artifactId>batik-transcoder</artifactId>
-        <version>1.7</version>
-    </dependency>
-    <dependency>
-        <groupId>com.lowagie</groupId>
-        <artifactId>itext</artifactId>
-        <version>2.1.5</version>
-    </dependency>
-    <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>20080701</version>
-    </dependency>
-    <dependency>
-        <groupId>javax.media</groupId>
-        <artifactId>jai_core</artifactId>
-        <version>1.1.3</version>
-    </dependency>
     <!-- SiRAC -->
     <!-- We are using versions 9999 because they are all custom jars to be used as-is -->
     <dependency>


### PR DESCRIPTION
## Description
This allows printing to work with annotations and other vector layers.
To solve the issue completely, the environments need to run tomcat under jdk 8 instead of jdk 7,

## Issues
 - Fix #406 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
