### PR TITLE
#409 Fix DashboardSave plugin, now it appears

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -37,7 +37,7 @@ import CreateNewMapPlugin from '@mapstore/plugins/CreateNewMap';
 import Dashboard from '@mapstore/plugins/Dashboard';
 import DashboardEditor from '@mapstore/plugins/DashboardEditor';
 import {
-    DashboardSaveAs as DashboardSavePlugin,
+    DashboardSave as DashboardSavePlugin,
     DashboardSaveAs as DashboardSaveAsPlugin
 } from '@mapstore/plugins/DashboardSave';
 import DashboardsPlugin from '@mapstore/plugins/Dashboards';


### PR DESCRIPTION
## Description
the dashboard Save plugin was not correctly imported in the bundle

## Issues
 - Fix #409


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Dashboard Save plugins is not available

**What is the new behavior?**
Dashboard Save plugins is available

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
