### PR TITLE
#417,#418,#419,#420 migrate localConfig.json

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -171,8 +171,7 @@
                 "pinchRotate": false
               }
             }
-          },
-          "tools": ["locate"]
+          }
         }
       }, "Version", "DrawerMenu",
       {
@@ -752,7 +751,6 @@
     "embedded": [{
         "name": "Map",
         "cfg": {
-          "tools": ["locate"],
           "mapOptions": {
             "openlayers": {
               "attribution": {
@@ -902,7 +900,6 @@
         "name": "Map",
         "cfg": {
           "mapType": "openlayers",
-          "tools": ["locate", "draw", "highlight"],
           "mapOptions": {
             "openlayers": {
               "interactions": {
@@ -1253,8 +1250,7 @@
             }
           }
         },
-        "mapType": "openlayers",
-        "tools": ["measurement", "locate", "draw", "highlight"]
+        "mapType": "openlayers"
       }
     }, "Notifications", "LavoriPubblici",
         {


### PR DESCRIPTION
## Description
Needed to remove `tools` configuration from any map.

Here in migration guidelines:
https://mapstore.readthedocs.io/en/latest/developer-guide/mapstore-migration-guide/#locate-plugin-configuration

@MV88 maybe the migration guidelines is not so clear about this point. Can you please improve doc. (If I undestood correctly, tools are not needed anymore now, right?)

## Issues
- #417
- #418 
- #419 
- #420 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
