### PR TITLE
#441 #449 #445 MapStore Updates and minor fixes

### DIFF
--- a/lavoriPubblici.html
+++ b/lavoriPubblici.html
@@ -92,14 +92,10 @@
         <link rel="stylesheet" href="dist/themes/comge.css">
 
         <link rel="shortcut icon" type="image/x-icon" href="assets/favicon.ico" />
-        <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
-        <link rel="stylesheet" href="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.css" />
         <!-- link rel="stylesheet" href="assets/css/mapstore2.css" -->
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.3.4/ol.js"></script>
-        <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
-        <script src="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.js"></script>
 
     </head>
     <body>

--- a/localConfig.json
+++ b/localConfig.json
@@ -499,9 +499,11 @@
             }
           ],
           "srsList": [
-                      {"name": "native", "label": "Native"},
-                      {"name": "EPSG:4326", "label": "WGS84"}
-              ],
+                { "name": "native", "label": "Native" },
+                { "name": "EPSG:3003", "label": "3003" },
+                { "name": "EPSG:7791", "label": "7791" },
+                { "name": "EPSG:4326", "label": "WGS84" }
+            ],
            "defaultSrs": "EPSG:4326"
         }
       }, {


### PR DESCRIPTION
## Description
This PR contains 
 - Update MapStore to latest 2021.01.xx
 - Changes in configuration to download in different SRS 
 - clean-up of `lavori-pubblici.hml` from cesium settings.

## Issues

 #441 #449 #445

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
