### PR TITLE
#507 Plugin to spawn persistent notifications in case of maintenance

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -996,7 +996,24 @@
       "cfg": {
           "enableContextManager": true
       }
-  }, "Login"],
+  }, "Login",
+      "Notifications",
+      {
+        "name": "MessageNotifier",
+        "cfg": {
+          "enabled": false,
+          "messages": [
+            {
+              "title": "notification.warning",
+              "message": "notification.maintenance",
+              "autoDismiss": 0,
+              "position": "tc",
+              "level": "warning"
+            }
+          ]
+        }
+      }
+    ],
     "maps": [{
         "name": "Header",
         "hide": true

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -65,6 +65,21 @@
             "extent": [1241482.0019, 973563.1609, 1830078.9331, 5215189.0853],
             "worldExtent": [6.6500, 8.8000, 12.0000, 47.0500]
         }],
+  "miscSettings": {
+    "messageNotifier": {
+      "enabled": true,
+      "initialDelay": 1000,
+      "messages": [
+        {
+          "title": "Avviso",
+          "message": "Gentile utente, dal 15/12/21 h 14.00 al 18/12/21 h 19.00 si potranno riscontrare alcuni disservizi del sistema. Verrà effettuato un aggiornamento dell'Infrastruttura Dati Territoriali e aggiunte nuove funzionalità, il tutto finalizzato a migliorare il servizio pubblico. Ci scusiamo per i possibili inconvenienti. Ufficio S.I.T.",
+          "autoDismiss": 0,
+          "position": "tc",
+          "level": "warning"
+        }
+      ]
+    }
+  },
   "initialState": {
     "defaultState": {
       "annotations": {
@@ -474,6 +489,7 @@
 
       },
       "Notifications",
+      "MessageNotifier",
       {
         "name": "LayerDownload",
         "cfg": {
@@ -998,21 +1014,7 @@
       }
   }, "Login",
       "Notifications",
-      {
-        "name": "MessageNotifier",
-        "cfg": {
-          "enabled": false,
-          "messages": [
-            {
-              "title": "notification.warning",
-              "message": "notification.maintenance",
-              "autoDismiss": 0,
-              "position": "tc",
-              "level": "warning"
-            }
-          ]
-        }
-      }
+      "MessageNotifier"
     ],
     "maps": [{
         "name": "Header",
@@ -1112,6 +1114,7 @@
       },
       "RulesDataGrid",
       "Notifications",
+      "MessageNotifier",
       {
         "name": "RulesEditor",
         "cfg": {
@@ -1181,7 +1184,8 @@
         "name": "Header",
         "hide": true
       },
-      "Notifications", "Home", {
+      "Notifications",
+      "MessageNotifier", "Home", {
         "name": "Cookie",
         "cfg": {
           "externalCookieUrl": "https://smart.comune.genova.it/node/8227",
@@ -1227,7 +1231,8 @@
         },
         "mapType": "openlayers"
       }
-    }, "Notifications", "LavoriPubblici",
+    }, "Notifications",
+      "MessageNotifier", "LavoriPubblici",
         {
       "name": "Search",
       "cfg": {
@@ -1328,6 +1333,7 @@
           }
         },
         "Notifications",
+        "MessageNotifier",
         {
           "name": "FeedbackMask",
           "cfg": {

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -67,7 +67,7 @@
         }],
   "miscSettings": {
     "messageNotifier": {
-      "enabled": true,
+      "enabled": false,
       "initialDelay": 1000,
       "messages": [
         {

--- a/js/actions/messagenotifier.js
+++ b/js/actions/messagenotifier.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const PERSIST_NOTIFICATION = "MESSAGENOTIFIER::PERSIST_NOTIFICATION";
+export const CEASE_NOTIFICATION = "MESSAGENOTIFIER::CEASE_NOTIFICATION";
+
+/**
+ * Adds notification into list of persistent notifications
+ * @memberof actions.messagenotifier
+ * @param {object} uid Unique message identifier
+ * @return {action} of type `PERSIST_NOTIFICATION`
+ */
+export function persistNotification(uid) {
+    return {
+        type: PERSIST_NOTIFICATION,
+        uid
+    };
+}
+/**
+ * Remove notification from the list of persistent notifications
+ * @memberof actions.messagenotifier
+ * @return {action} of type `CEASE_NOTIFICATION`
+ */
+export function ceaseNotification(uid) {
+    return {
+        type: CEASE_NOTIFICATION,
+        uid
+    };
+}
+
+
+export default {
+    PERSIST_NOTIFICATION, persistNotification,
+    CEASE_NOTIFICATION, ceaseNotification,
+};

--- a/js/actions/messagenotifier.js
+++ b/js/actions/messagenotifier.js
@@ -7,18 +7,33 @@
  */
 
 export const PERSIST_NOTIFICATION = "MESSAGENOTIFIER::PERSIST_NOTIFICATION";
+export const PERSIST_NOTIFICATIONS = "MESSAGENOTIFIER::PERSIST_NOTIFICATIONS";
 export const CEASE_NOTIFICATION = "MESSAGENOTIFIER::CEASE_NOTIFICATION";
+export const INITIALIZE = "MESSAGENOTIFIER::INITIALIZE";
 
 /**
  * Adds notification into list of persistent notifications
  * @memberof actions.messagenotifier
- * @param {object} uid Unique message identifier
+ * @param {string} uid Unique message identifier
  * @return {action} of type `PERSIST_NOTIFICATION`
  */
 export function persistNotification(uid) {
     return {
         type: PERSIST_NOTIFICATION,
         uid
+    };
+}
+
+/**
+ * Adds notifications into list of persistent notifications
+ * @memberof actions.messagenotifier
+ * @param {array} uids Unique message identifier
+ * @return {action} of type `PERSIST_NOTIFICATION`
+ */
+export function persistNotifications(uids) {
+    return {
+        type: PERSIST_NOTIFICATIONS,
+        uids
     };
 }
 /**
@@ -33,8 +48,21 @@ export function ceaseNotification(uid) {
     };
 }
 
+/**
+ * Set initialized flag to true.
+ * @memberof actions.messagenotifier
+ * @return {action} of type `INITIALIZE`
+ */
+export function initialize() {
+    return {
+        type: INITIALIZE
+    };
+}
+
 
 export default {
     PERSIST_NOTIFICATION, persistNotification,
-    CEASE_NOTIFICATION, ceaseNotification
+    PERSIST_NOTIFICATIONS, persistNotifications,
+    CEASE_NOTIFICATION, ceaseNotification,
+    INITIALIZE, initialize
 };

--- a/js/actions/messagenotifier.js
+++ b/js/actions/messagenotifier.js
@@ -36,5 +36,5 @@ export function ceaseNotification(uid) {
 
 export default {
     PERSIST_NOTIFICATION, persistNotification,
-    CEASE_NOTIFICATION, ceaseNotification,
+    CEASE_NOTIFICATION, ceaseNotification
 };

--- a/js/epics/messagenotifier.js
+++ b/js/epics/messagenotifier.js
@@ -30,8 +30,8 @@ export const makeNotificationPersistent = action$ =>
 export const ceaseNotificationPersistence = (action$, store) =>
     action$.ofType(HIDE_NOTIFICATION)
         .switchMap(({uid}) => {
-            const messageNotifierState = store.getState().messageNotifier
-            const isPersistent = size(filter(get(messageNotifierState, 'persistentNotifications', []), (el) => el === uid))
+            const messageNotifierState = store.getState().messageNotifier;
+            const isPersistent = size(filter(get(messageNotifierState, 'persistentNotifications', []), (el) => el === uid));
             return Rx.Observable.of(isPersistent ? ceaseNotification(uid) : false);
         });
 

--- a/js/epics/messagenotifier.js
+++ b/js/epics/messagenotifier.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import Rx from 'rxjs';
+
+import { ceaseNotification, persistNotification } from '../actions/messagenotifier';
+import { SHOW_NOTIFICATION, HIDE_NOTIFICATION } from "@mapstore/actions/notifications";
+import { size, filter, get } from 'lodash';
+
+/**
+ * Persist notification that is marked as persistent.
+ * @param {external:Observable} action$ manages `SHOW_NOTIFICATION`.
+ * @memberof epics.messagenotifier
+ * @return {external:Observable}
+ */
+export const makeNotificationPersistent = action$ =>
+    action$.ofType(SHOW_NOTIFICATION)
+        .switchMap((notification) => Rx.Observable.of(notification.persistent ? persistNotification(notification.uid) : false));
+
+/**
+ * Cease notification that is marked as persistent.
+ * @param {external:Observable} action$ manages `HIDE_NOTIFICATION`.
+ * @memberof epics.messagenotifier
+ * @return {external:Observable}
+ */
+export const ceaseNotificationPersistence = (action$, store) =>
+    action$.ofType(HIDE_NOTIFICATION)
+        .switchMap(({uid}) => {
+            const messageNotifierState = store.getState().messageNotifier
+            const isPersistent = size(filter(get(messageNotifierState, 'persistentNotifications', []), (el) => el === uid))
+            return Rx.Observable.of(isPersistent ? ceaseNotification(uid) : false);
+        });
+
+/**
+ * Epics for notifications
+ * @name epics.notifications
+ * @type {Object}
+ */
+
+export default {
+    makeNotificationPersistent,
+    ceaseNotificationPersistence
+};

--- a/js/epics/messagenotifier.js
+++ b/js/epics/messagenotifier.js
@@ -7,19 +7,9 @@
 */
 import Rx from 'rxjs';
 
-import { ceaseNotification, persistNotification } from '../actions/messagenotifier';
-import { SHOW_NOTIFICATION, HIDE_NOTIFICATION } from "@mapstore/actions/notifications";
+import { ceaseNotification } from '../actions/messagenotifier';
+import { HIDE_NOTIFICATION } from "@mapstore/actions/notifications";
 import { size, filter, get } from 'lodash';
-
-/**
- * Persist notification that is marked as persistent.
- * @param {external:Observable} action$ manages `SHOW_NOTIFICATION`.
- * @memberof epics.messagenotifier
- * @return {external:Observable}
- */
-export const makeNotificationPersistent = action$ =>
-    action$.ofType(SHOW_NOTIFICATION)
-        .switchMap((notification) => Rx.Observable.of(notification.persistent ? persistNotification(notification.uid) : false));
 
 /**
  * Cease notification that is marked as persistent.
@@ -42,6 +32,5 @@ export const ceaseNotificationPersistence = (action$, store) =>
  */
 
 export default {
-    makeNotificationPersistent,
     ceaseNotificationPersistence
 };

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -15,6 +15,7 @@ import FooterPlugin from './plugins/Footer';
 import GeoNetworkLinkPlugin from './plugins/GeoNetworkLink';
 import HeaderPlugin from './plugins/Header';
 import LoginPlugin from './plugins/Login';
+import MessageNotifier from "./plugins/MessageNotifier";
 import LoginModalPlugin from './plugins/LoginModal';
 import PrivacyNote from './plugins/PrivacyNote';
 // product plugins
@@ -201,6 +202,7 @@ export default {
         MapTemplatesPlugin,
         MeasurePlugin,
         MediaEditorPlugin,
+        MessageNotifier,
         MetadataExplorerPlugin,
         MousePositionPlugin,
         NotificationsPlugin,

--- a/js/plugins/MessageNotifier.jsx
+++ b/js/plugins/MessageNotifier.jsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useEffect, useState} from 'react';
+import { connect } from 'react-redux';
+import { size, map, forEach, includes, filter } from 'lodash';
+import messageNotifier from '@js/reducers/messagenotifier';
+import epics from '@js/epics/messagenotifier';
+
+
+import {show} from '@mapstore/actions/notifications';
+import {createPlugin}  from '@mapstore/utils/PluginsUtils';
+import { createStructuredSelector } from 'reselect';
+import {locationSelector, persistentNotificationsSelector} from "@js/selector/cantieri";
+import assign from "object-assign";
+
+/**
+ * Plugin to display messages during maintenance
+ * @name MessageNotifier
+ * @memberof plugins
+ * @static
+ * @example
+ * {name: "MessageNotifier"}
+ */
+const MessageNotifier = ({ location, persistentNotifications, show, pluginCfg: {
+    messages = [],
+    enabled = false,
+    initialDelay = 500
+} }) => {
+    const [notifications, setNotifications] = useState([]);
+    useEffect(() => {
+        if (messages.length && enabled) {
+            const mapped = map(messages, (el,idx) => {
+                return assign({}, el, {uid: el.uid ?? Date.now()+idx, level: el.level ?? 'info'});
+            });
+            setNotifications(mapped);
+        }
+    }, []);
+    useEffect(() => {
+        forEach(notifications, (notification) => {
+            // @todo: Use smarter way to wait while page is fully loaded
+            setTimeout(function() {
+                show({
+                    ...notification,
+                    persistent: true
+                }, notification.level);
+            }, initialDelay);
+        });
+    }, [notifications]);
+
+    useEffect(() => {
+        // Respawn notifications that were persistent by setting persistency flag
+        const persistent = filter(notifications, (el) => includes(persistentNotifications, el.uid));
+        if (persistent.length) {
+            setNotifications(persistent);
+        }
+    }, [location.pathname, location.hash]);
+
+    return false;
+}
+
+export default createPlugin('MessageNotifier', {
+    component: connect(createStructuredSelector({
+        location: locationSelector,
+        persistentNotifications: persistentNotificationsSelector,
+        }),
+        {
+            show: show,
+        }
+    )(MessageNotifier),
+    reducers: {
+        messageNotifier
+    },
+    epics
+});

--- a/js/plugins/MessageNotifier.jsx
+++ b/js/plugins/MessageNotifier.jsx
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import { connect } from 'react-redux';
-import { size, map, forEach, includes, filter } from 'lodash';
+import { map, forEach, includes, filter } from 'lodash';
 import messageNotifier from '@js/reducers/messagenotifier';
 import epics from '@js/epics/messagenotifier';
 
@@ -27,7 +27,7 @@ import assign from "object-assign";
  * @example
  * {name: "MessageNotifier"}
  */
-const MessageNotifier = ({ location, persistentNotifications, show, pluginCfg: {
+const MessageNotifier = ({ location, persistentNotifications, showNotification, pluginCfg: {
     messages = [],
     enabled = false,
     initialDelay = 500
@@ -35,8 +35,8 @@ const MessageNotifier = ({ location, persistentNotifications, show, pluginCfg: {
     const [notifications, setNotifications] = useState([]);
     useEffect(() => {
         if (messages.length && enabled) {
-            const mapped = map(messages, (el,idx) => {
-                return assign({}, el, {uid: el.uid ?? Date.now()+idx, level: el.level ?? 'info'});
+            const mapped = map(messages, (el, idx) => {
+                return assign({}, el, {uid: el.uid ?? Date.now() + idx, level: el.level ?? 'info'});
             });
             setNotifications(mapped);
         }
@@ -45,7 +45,7 @@ const MessageNotifier = ({ location, persistentNotifications, show, pluginCfg: {
         forEach(notifications, (notification) => {
             // @todo: Use smarter way to wait while page is fully loaded
             setTimeout(function() {
-                show({
+                showNotification({
                     ...notification,
                     persistent: true
                 }, notification.level);
@@ -62,16 +62,16 @@ const MessageNotifier = ({ location, persistentNotifications, show, pluginCfg: {
     }, [location.pathname, location.hash]);
 
     return false;
-}
+};
 
 export default createPlugin('MessageNotifier', {
     component: connect(createStructuredSelector({
         location: locationSelector,
-        persistentNotifications: persistentNotificationsSelector,
-        }),
-        {
-            show: show,
-        }
+        persistentNotifications: persistentNotificationsSelector
+    }),
+    {
+        showNotification: show
+    }
     )(MessageNotifier),
     reducers: {
         messageNotifier

--- a/js/reducers/messagenotifier.js
+++ b/js/reducers/messagenotifier.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { CEASE_NOTIFICATION, PERSIST_NOTIFICATION
+}  from '../actions/messagenotifier';
+import assign  from 'object-assign';
+import { filter } from 'lodash';
+
+function messageNotifier(state = {
+    persistentNotifications: [],
+}, action) {
+    switch (action.type) {
+    case PERSIST_NOTIFICATION: {
+        return assign({}, state, { persistentNotifications: [...state.persistentNotifications, action.uid] } );
+    }
+    case CEASE_NOTIFICATION: {
+        return assign({}, state, { persistentNotifications: filter(state.persistentNotifications, (el) => el !== action.uid) } );
+    }
+    default:
+        return state;
+    }
+}
+
+export default messageNotifier;

--- a/js/reducers/messagenotifier.js
+++ b/js/reducers/messagenotifier.js
@@ -6,17 +6,38 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { CEASE_NOTIFICATION, PERSIST_NOTIFICATION
-}  from '../actions/messagenotifier';
+import {
+    CEASE_NOTIFICATION, PERSIST_NOTIFICATIONS, PERSIST_NOTIFICATION, INITIALIZE
+} from '../actions/messagenotifier';
 import assign  from 'object-assign';
-import { filter } from 'lodash';
+import { filter, union } from 'lodash';
 
 function messageNotifier(state = {
-    persistentNotifications: []
+    persistentNotifications: [],
+    initialized: false
 }, action) {
     switch (action.type) {
     case PERSIST_NOTIFICATION: {
-        return assign({}, state, { persistentNotifications: [...state.persistentNotifications, action.uid] } );
+        const isPersistent = filter(state.persistentNotifications, (el) => el.uid === action.uid).length > 0;
+        return assign(
+            {},
+            state,
+            { persistentNotifications: isPersistent ? [...state.persistentNotifications] : [...state.persistentNotifications, action] }
+        );
+    }
+    case PERSIST_NOTIFICATIONS: {
+        return assign(
+            {},
+            state,
+            { persistentNotifications: union(state.persistentNotifications, action.uids) }
+        );
+    }
+    case INITIALIZE: {
+        return assign(
+            {},
+            state,
+            { initialized: true }
+        );
     }
     case CEASE_NOTIFICATION: {
         return assign({}, state, { persistentNotifications: filter(state.persistentNotifications, (el) => el !== action.uid) } );

--- a/js/reducers/messagenotifier.js
+++ b/js/reducers/messagenotifier.js
@@ -12,7 +12,7 @@ import assign  from 'object-assign';
 import { filter } from 'lodash';
 
 function messageNotifier(state = {
-    persistentNotifications: [],
+    persistentNotifications: []
 }, action) {
     switch (action.type) {
     case PERSIST_NOTIFICATION: {

--- a/js/selector/cantieri.js
+++ b/js/selector/cantieri.js
@@ -11,7 +11,9 @@ export const areasLayerSelector = (state) => get(state, "layers.flat").filter(l 
 export const serviceRESTUrlSelector = (state) => get(state, "cantieri.serviceRESTUrl");
 export const routingSelector = state => get(state, "routing.location.pathname");
 export const locationSelector = state => get(state, "router.location");
+export const notificationsSelector = state => get(state, "notifications");
 export const persistentNotificationsSelector = state => get(state, "messageNotifier.persistentNotifications");
+export const persistentNotificationsState = state => get(state, "messageNotifier.initialized");
 
 export default {
     stateSelector,
@@ -19,5 +21,7 @@ export default {
     areasLayerSelector,
     serviceRESTUrlSelector,
     routingSelector,
-    persistentNotificationsSelector
+    notificationsSelector,
+    persistentNotificationsSelector,
+    persistentNotificationsState
 };

--- a/js/selector/cantieri.js
+++ b/js/selector/cantieri.js
@@ -10,11 +10,14 @@ export const elementsLayerSelector = (state) => get(state, "layers.flat").filter
 export const areasLayerSelector = (state) => get(state, "layers.flat").filter(l => l.id === AREAS_LAYER)[0];
 export const serviceRESTUrlSelector = (state) => get(state, "cantieri.serviceRESTUrl");
 export const routingSelector = state => get(state, "routing.location.pathname");
+export const locationSelector = state => get(state, "router.location");
+export const persistentNotificationsSelector = state => get(state, "messageNotifier.persistentNotifications");
 
 export default {
     stateSelector,
     elementsLayerSelector,
     areasLayerSelector,
     serviceRESTUrlSelector,
-    routingSelector
+    routingSelector,
+    persistentNotificationsSelector
 };


### PR DESCRIPTION
## Description
Plugin to spawn persistent notifications in case of maintenance

## Issues
 #507 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#507 

**What is the new behavior?**
Implemented new plugin to have approach define persistent but dismissable messages that will be visible to users via plugin and its configuration.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
- With the sample configuration plugin appears only on Home page, therefore messages are visible only there.
- If message was not closed by the user, it will re-appear once user gets back to the page where plugin appears.
- Delay setting is introduced due to misbehavior of react-notification-system in terms of notification height calculation.